### PR TITLE
Switch to AGP gradle-api artifact

### DIFF
--- a/checkstyle-android-plugin/build.gradle
+++ b/checkstyle-android-plugin/build.gradle
@@ -12,7 +12,7 @@ version = "1.0.0"
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
-    implementation "com.android.tools.build:gradle:8.0.0-alpha10"
+    implementation "com.android.tools.build:gradle-api:8.0.0-alpha11"
 }
 
 gradlePlugin {

--- a/checkstyle-android-plugin/src/main/kotlin/com/drewhannay/checkstyle/CheckstyleAndroidExtension.kt
+++ b/checkstyle-android-plugin/src/main/kotlin/com/drewhannay/checkstyle/CheckstyleAndroidExtension.kt
@@ -1,14 +1,10 @@
 package com.drewhannay.checkstyle
 
-import com.android.build.api.dsl.AndroidSourceSet
-import org.gradle.api.NamedDomainObjectContainer
 import org.gradle.api.Project
 import org.gradle.api.plugins.quality.CheckstyleExtension
 import org.gradle.api.tasks.SourceSet
 
 open class CheckstyleAndroidExtension(project: Project) : CheckstyleExtension(project) {
-
-    var androidSourceSets: NamedDomainObjectContainer<out AndroidSourceSet>? = null
 
     /**
      * [SourceSet] does not apply for Android projects


### PR DESCRIPTION
Notable change: Tasks are now created for each variant component rather than for each source set. This means that when a variant component doesn't exist (e.g. test fixtures not enabled, or unit tests disabled, etc) that tasks won't be created, which is great.

It also means that there is now no longer a common "checkstyleMain" task. Instead, there are only "checkstyleDebug" and "checkstyleRelease" tasks which have a large overlap in which files they will scan. This is not ideal, but probably the best way to move forward until AGP potentially adds support for a use case like this (which likely wouldn't be until after AGP 9 at the earliest).

One other notable point: Instead of making the "check" task depend on each of the various "checkstyleXXX" tasks, we now make it depend only on the parent "checkstyle" task, which in turn depends on each of the "checkstyleXXX" tasks. I'm not entirely sure why the original code was configured this way in the first place, so I'm not sure if this is a fully safe change, but I can't think of any behavior differences this might cause.